### PR TITLE
[BREAKING] [Feat] Multi round responding

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,25 @@ I hope you like it! Let me know if there's anything else I can help you with.
 
     session = Session([your_module_a, your_module_b])
 
-    session.ask("your prompt")
+    for reply in session.ask("your prompt"):
+        # session.ask will yield each time the api returns a result,
+        # before calling function, it will print the function name and args.
+        # e.g. here's a function call:
+        # {
+        #   "role": "assistant",
+        #   "content": null,
+        #   "function_call": {
+        #     "name": "examples-draw_and_wrapper_md-draw",
+        #     "arguments": "{\n  \"prompt\": \"cat\"\n}"
+        #   }
+        # }
+        # 
+        # while here's a normal reply:
+        # {
+        #   "role": "assistant",
+        #   "content": "Hello, I am an AI assistant. How can I assist you today?"
+        # }
+        print(reply)
     ```
 
     `Session` will automatically manage context for you.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,19 @@ Then you can talk to the bot.
 ```
 $ python main.py examples/greet.py 
 Using module: examples.greet
->>> hello and who are you?              
-<<< Hello! I am an AI assistant here to help you. How may I assist you today?
+>>> Hello and who are you?
+<<< Hello! I am an AI assistant. How can I assist you today?
 >>> say hello to Rock
-func<examples.greet.greet>: Hello, Rock!
+call<examples-greet-greet>: {
+  "user": "Rock"
+}
+<<< Hello, Rock! How can I assist you today?
 >>> and to Alice
-func<examples.greet.greet>: Hello, Alice!
->>> 
+call<examples-greet-greet>: {
+  "user": "Alice"
+}
+<<< Hello, Alice! How can I assist you today?
+>>>
 ```
 
 Type `help` to get help.  
@@ -62,27 +68,29 @@ See [wiki](https://github.com/RockChinQ/CallingGPT/wiki/1.-Function-Format) for 
 ### Other Examples
 
 <details>
-<summary>examples/draw.py</summary>
+<summary>examples/draw_and_wrapper_md.py </summary>
 
 Provides a `dalle_draw` function to use DALL·E model when user ask GPT to draw something.
 
 ```bash
-python main.py examples/draw.py
+python main.py examples/draw_and_wrapper_md.py 
 ```
 
 ```
-$ python main.py examples/draw.py 
-Using module: examples.draw
->>> draw cars heading home under the sunset
-func<examples.draw.dalle_draw>: {
-  "created": 1687098971,
-  "data": [
-    {
-      "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-VS9HEpJba78GXVfOcmVo7qaM/user-OHa7Jo3kL4XJDg9lo7AzdWNT/img-eAwt4YgHn6ed1cr96MoRWs0d.png?st=2023-06-18T13%3A36%3A11Z&se=2023-06-18T15%3A36%3A11Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2023-06-17T20%3A54%3A10Z&ske=2023-06-18T20%3A54%3A10Z&sks=b&skv=2021-08-06&sig=ZY4DTE1fYPyT7/jYBLJLuAgxpNuPsOhjbid1CWTyfKo%3D"
-    }
-  ]
+$ python main.py examples/draw_and_wrapper_md.py 
+Using module: examples.draw_and_wrapper_md
+>>> hello!
+<<< Hi there! How can I assist you today?
+>>> draw a sunset for me please
+call<examples-draw_and_wrapper_md-draw>: {
+  "prompt": "sunset"
 }
->>>
+<<< Sure! Here's a beautiful sunset for you:
+
+![Sunset](https://oaidalleapiprodscus.blob.core.windows.net/private/org-VS9HEpJba78GXVfOcmVo7qaM/user-OHa7Jo3kL4XJDg9lo7AzdWNT/img-QmDUiwp1IGFcu8pDGZh0i7r8.png)
+
+I hope you like it! Let me know if there's anything else I can help you with.
+>>> 
 ```
 
 </details>

--- a/examples/draw_and_wrapper_md.py
+++ b/examples/draw_and_wrapper_md.py
@@ -1,0 +1,27 @@
+import openai
+
+
+def draw(prompt: str) -> dict:
+    """
+    Draw a picture from a prompt using DALL-E.
+
+    Args:
+        prompt(str): The prompt to draw from.
+    """
+    return openai.Image.create(
+        prompt=prompt,
+    )
+
+def output_img_as_md(img: str) -> str:
+    """
+    Output an image as Markdown.
+
+    Args:
+        img(str): The image to output.
+    """
+    return "![Generated Image]({})".format(img)
+
+__functions__ = [
+    draw,
+    output_img_as_md
+]

--- a/src/CallingGPT/cli/__init__.py
+++ b/src/CallingGPT/cli/__init__.py
@@ -41,18 +41,33 @@ def cli_loop(modules: list):
         else:
             resp = session.ask(cmd)
 
-            if resp['type'] == 'function_call':
-                print(
-                    "func<{}>: {}".format(
-                        resp['func'],
-                        resp['value']
+            for repl in resp:
+                if 'function_call' in repl:
+                    print(
+                        "call<{}>: {}".format(
+                            repl['function_call']['name'],
+                            repl['function_call']['arguments']
+                        )
                     )
-                )
-            elif resp['type'] == 'message':
-                print(
-                    "<<< {}".format(
-                        resp['value']
+                else:
+                    print(
+                        "<<< {}".format(
+                            repl['content']
+                        )
                     )
-                )
+
+            # if resp['type'] == 'function_call':
+            #     print(
+            #         "func<{}>: {}".format(
+            #             resp['func'],
+            #             resp['value']
+            #         )
+            #     )
+            # elif resp['type'] == 'message':
+            #     print(
+            #         "<<< {}".format(
+            #             resp['value']
+            #         )
+            #     )
 
         cmd = input(">>> ")

--- a/src/CallingGPT/session/session.py
+++ b/src/CallingGPT/session/session.py
@@ -16,7 +16,7 @@ class Session:
         self.namespace = Namespace(modules)
         self.model = model
 
-    def ask_iter(self, msg: str) -> dict:
+    def ask(self, msg: str) -> dict:
         # copy messages
 
         messages = self.messages.copy()
@@ -84,61 +84,61 @@ class Session:
                 yield ret
                 break
 
-    def ask(self, msg: str) -> dict:
-        self.messages.append(
-            {
-                "role": "user",
-                "content": msg
-            }
-        )
+    # def ask(self, msg: str) -> dict:
+    #     self.messages.append(
+    #         {
+    #             "role": "user",
+    #             "content": msg
+    #         }
+    #     )
 
-        args = {
-            "model": self.model,
-            "messages": self.messages,
-        }
+    #     args = {
+    #         "model": self.model,
+    #         "messages": self.messages,
+    #     }
 
-        if len(self.namespace.functions_list) > 0:
-            args['functions'] = self.namespace.functions_list
-            args['function_call'] = "auto"
+    #     if len(self.namespace.functions_list) > 0:
+    #         args['functions'] = self.namespace.functions_list
+    #         args['function_call'] = "auto"
 
-        resp = openai.ChatCompletion.create(
-            **args
-        )
+    #     resp = openai.ChatCompletion.create(
+    #         **args
+    #     )
 
-        logging.debug("Response: {}".format(resp))
-        reply_msg = resp["choices"][0]['message']
+    #     logging.debug("Response: {}".format(resp))
+    #     reply_msg = resp["choices"][0]['message']
 
-        ret = {}
+    #     ret = {}
 
-        if 'function_call' in reply_msg:
+    #     if 'function_call' in reply_msg:
 
-            fc = reply_msg['function_call']
-            args = json.loads(fc['arguments'])
-            call_ret = self._call_function(fc['name'], args)
+    #         fc = reply_msg['function_call']
+    #         args = json.loads(fc['arguments'])
+    #         call_ret = self._call_function(fc['name'], args)
 
-            self.messages.append({
-                "role": "function",
-                "name": fc['name'],
-                "content": str(call_ret)
-            })
+    #         self.messages.append({
+    #             "role": "function",
+    #             "name": fc['name'],
+    #             "content": str(call_ret)
+    #         })
 
-            ret = {
-                "type": "function_call",
-                "func": fc['name'].replace('-', '.'),
-                "value": call_ret,
-            }
-        else:
-            ret = {
-                "type": "message",
-                "value": reply_msg['content'],
-            }
+    #         ret = {
+    #             "type": "function_call",
+    #             "func": fc['name'].replace('-', '.'),
+    #             "value": call_ret,
+    #         }
+    #     else:
+    #         ret = {
+    #             "type": "message",
+    #             "value": reply_msg['content'],
+    #         }
 
-            self.messages.append({
-                "role": "assistant",
-                "content": reply_msg['content']
-            })
+    #         self.messages.append({
+    #             "role": "assistant",
+    #             "content": reply_msg['content']
+    #         })
 
-        return ret
+    #     return ret
 
     def _call_function(self, function_name: str, args: dict):
         return self.namespace.call_function(function_name, args)

--- a/src/CallingGPT/session/session.py
+++ b/src/CallingGPT/session/session.py
@@ -45,6 +45,8 @@ class Session:
             logging.debug("Response: {}".format(resp))
             reply_msg = resp["choices"][0]['message']
 
+            yield reply_msg
+
             ret = {}
 
             if 'function_call' in reply_msg:
@@ -67,7 +69,6 @@ class Session:
                     "value": call_ret,
                 }
 
-                yield ret
             else:
                 ret = {
                     "type": "message",
@@ -81,7 +82,6 @@ class Session:
 
                 self.messages = messages.copy()
 
-                yield ret
                 break
 
     # def ask(self, msg: str) -> dict:

--- a/src/CallingGPT/session/session.py
+++ b/src/CallingGPT/session/session.py
@@ -62,19 +62,7 @@ class Session:
                 })
 
                 self.messages = messages.copy()
-
-                ret = {
-                    "type": "function_call",
-                    "func": fc['name'].replace('-', '.'),
-                    "value": call_ret,
-                }
-
             else:
-                ret = {
-                    "type": "message",
-                    "value": reply_msg['content'],
-                }
-
                 messages.append({
                     "role": "assistant",
                     "content": reply_msg['content']
@@ -83,62 +71,6 @@ class Session:
                 self.messages = messages.copy()
 
                 break
-
-    # def ask(self, msg: str) -> dict:
-    #     self.messages.append(
-    #         {
-    #             "role": "user",
-    #             "content": msg
-    #         }
-    #     )
-
-    #     args = {
-    #         "model": self.model,
-    #         "messages": self.messages,
-    #     }
-
-    #     if len(self.namespace.functions_list) > 0:
-    #         args['functions'] = self.namespace.functions_list
-    #         args['function_call'] = "auto"
-
-    #     resp = openai.ChatCompletion.create(
-    #         **args
-    #     )
-
-    #     logging.debug("Response: {}".format(resp))
-    #     reply_msg = resp["choices"][0]['message']
-
-    #     ret = {}
-
-    #     if 'function_call' in reply_msg:
-
-    #         fc = reply_msg['function_call']
-    #         args = json.loads(fc['arguments'])
-    #         call_ret = self._call_function(fc['name'], args)
-
-    #         self.messages.append({
-    #             "role": "function",
-    #             "name": fc['name'],
-    #             "content": str(call_ret)
-    #         })
-
-    #         ret = {
-    #             "type": "function_call",
-    #             "func": fc['name'].replace('-', '.'),
-    #             "value": call_ret,
-    #         }
-    #     else:
-    #         ret = {
-    #             "type": "message",
-    #             "value": reply_msg['content'],
-    #         }
-
-    #         self.messages.append({
-    #             "role": "assistant",
-    #             "content": reply_msg['content']
-    #         })
-
-    #     return ret
 
     def _call_function(self, function_name: str, args: dict):
         return self.namespace.call_function(function_name, args)


### PR DESCRIPTION
# This PR made some Breaking Changes

- `Session.ask` is now a `iterator`
- `Session.ask` yield GPT's response before calling function
- If GPT returns a non-function-calling(normal message) response, `Session.ask` yield it and finish.

## Practice

```python
from CallingGPT.session.session import Session

from examples import draw_and_wrapper_md

import openai
import os

openai.api_key = os.environ["openai_apikey"]

ns = Session([draw_and_wrapper_md])

iter = ns.ask("draw a cat, then convert to markdown")

for n in iter:
    print(n)
```

outputs:

```
$ python test.py 
{
  "role": "assistant",
  "content": null,
  "function_call": {
    "name": "examples-draw_and_wrapper_md-draw",
    "arguments": "{\n  \"prompt\": \"cat\"\n}"
  }
}
{
  "role": "assistant",
  "content": null,
  "function_call": {
    "name": "examples-draw_and_wrapper_md-output_img_as_md",
    "arguments": "{\n  \"img\": \"https://oaidalleapiprodscus.blob.core.windows.net/private/org-VS9HEpJba78GXVfOcmVo7qaM/user-OHa7Jo3kL4XJDg9lo7AzdWNT/img-qsC6f6I0mg7WGa1U5M7IdgpY.png?st=2023-07-08T00%3A32%3A39Z&se=2023-07-08T02%3A32%3A39Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2023-07-07T22%3A11%3A30Z&ske=2023-07-08T22%3A11%3A30Z&sks=b&skv=2021-08-06&sig=L6RCx9RFpbjYZaixlNYWUov9kakIgdDN32KnKFQEBIg%3D\"\n}"
  }
}
{
  "role": "assistant",
  "content": "![Generated Image](https://oaidalleapiprodscus.blob.core.windows.net/private/org-VS9HEpJba78GXVfOcmVo7qaM/user-OHa7Jo3kL4XJDg9lo7AzdWNT/img-qsC6f6I0mg7WGa1U5M7IdgpY.png?st=2023-07-08T00%3A32%3A39Z&se=2023-07-08T02%3A32%3A39Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2023-07-07T22%3A11%3A30Z&ske=2023-07-08T22%3A11%3A30Z&sks=b&skv=2021-08-06&sig=L6RCx9RFpbjYZaixlNYWUov9kakIgdDN32KnKFQEBIg%3D)"
}
```

